### PR TITLE
使用IsConnectionOpen替换IsConnected

### DIFF
--- a/base_device.go
+++ b/base_device.go
@@ -149,7 +149,7 @@ func (device *baseIotDevice) DisConnect() {
 }
 func (device *baseIotDevice) IsConnected() bool {
 	if device.Client != nil {
-		return device.Client.IsConnected()
+		return device.Client.IsConnectionOpen()
 	}
 
 	return false


### PR DESCRIPTION
这里判断是否连接成功使用IsConnectionOpen()方法更准确，因为在断线重连状态IsConnected()也会返回true，但是当断线状态调用BatchReportSubDevicesProperties()会造成阻塞，且无法恢复